### PR TITLE
Configure docker compose with env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+TZ=America/Recife
+WEBPASSWORD=uma_senha_bem_segura

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copie este arquivo para .env e ajuste os valores conforme necessário.
+TZ=America/Recife
+WEBPASSWORD=troque_esta_senha

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# pihole
+# Pi-hole Docker Setup
+
+Este repositório contém uma configuração básica do Pi-hole utilizando Docker Compose.
+
+## Como usar
+
+1. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis de acordo com o seu ambiente.
+2. Inicie os serviços com `docker compose up -d`.
+
+O arquivo `docker-compose.yml` já está configurado para mapear os volumes do Pi-hole e expor as portas necessárias.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  pihole:
+    image: pihole/pihole:latest
+    container_name: pihole
+    hostname: pihole
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "80:80/tcp"
+    environment:
+      TZ: ${TZ}
+      WEBPASSWORD: ${WEBPASSWORD}
+    volumes:
+      - './etc-pihole/:/etc/pihole/'
+      - './etc-dnsmasq.d/:/etc/dnsmasq.d/'
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN


### PR DESCRIPTION
## Summary
- add a docker-compose definition for running Pi-hole with Docker
- document how to start the stack and manage environment variables
- provide .env and .env.example files for configuring timezone and admin password

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf2d59eb483258097f0168e87066d